### PR TITLE
fix: pkg_resources -> importlib

### DIFF
--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -3,20 +3,30 @@ name: Tox tests
 on: [push]
 
 jobs:
-  build_test:
-    runs-on: ubuntu-20.04
+  test:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6]
+        python: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Install Tox and any other packages
+      - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        # Run tox using the version of Python in `PATH`
+        run: tox -e py
+
+  test-py36:
+    runs-on: ubuntu-latest
+    container: python:3.6-slim
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
         run: tox -e py

--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -10,9 +10,9 @@ jobs:
         python: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
@@ -25,7 +25,7 @@ jobs:
     container: python:3.6-slim
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/hls_manifest/hls_manifest.py
+++ b/hls_manifest/hls_manifest.py
@@ -15,9 +15,9 @@ import json
 import hashlib
 from datetime import datetime
 try:
-    from importlib.resources import open_binary
-except ImportError:  # Python 3.6
-    from importlib_resources import open_binary
+    from importlib.resources import files as resource_files
+except ImportError:  # Python < 3.9
+    from importlib_resources import files as resource_files
 from jsonschema import validate
 from urllib.parse import urlparse
 
@@ -126,7 +126,7 @@ def main(inputdir, outputfile, bucket, collection, product, jobid, gibs):
     }
 
     schema = json.load(
-        open_binary("hls_manifest", "schema/cumulus_sns_schema_v1.4.1.json")
+        resource_files("hls_manifest").joinpath("schema/cumulus_sns_schema_v1.4.1.json").open("rb")
     )
 
     validate(instance=manifest, schema=schema)

--- a/hls_manifest/hls_manifest.py
+++ b/hls_manifest/hls_manifest.py
@@ -14,7 +14,10 @@ import os
 import json
 import hashlib
 from datetime import datetime
-from pkg_resources import resource_stream
+try:
+    from importlib.resources import open_binary
+except ImportError:  # Python 3.6
+    from importlib_resources import open_binary
 from jsonschema import validate
 from urllib.parse import urlparse
 
@@ -123,7 +126,7 @@ def main(inputdir, outputfile, bucket, collection, product, jobid, gibs):
     }
 
     schema = json.load(
-        resource_stream("hls_manifest", "schema/cumulus_sns_schema_v1.4.1.json")
+        open_binary("hls_manifest", "schema/cumulus_sns_schema_v1.4.1.json")
     )
 
     validate(instance=manifest, schema=schema)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="hls_manifest",
     version="0.1",
     packages=find_packages(),
-    install_requires=["click", "jsonschema", "importlib_resources; python_version < '3.7'"],
+    install_requires=["click", "jsonschema", "importlib_resources; python_version < '3.9'"],
     include_package_data=True,
     package_data={"hls_manifest": ["schema/*.json", ]},
     extras_require={"dev": ["flake8", "black"], "test": ["flake8", "pytest"]},

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="hls_manifest",
     version="0.1",
     packages=find_packages(),
-    install_requires=["click", "jsonschema"],
+    install_requires=["click", "jsonschema", "importlib_resources; python_version < '3.7'"],
     include_package_data=True,
     package_data={"hls_manifest": ["schema/*.json", ]},
     extras_require={"dev": ["flake8", "black"], "test": ["flake8", "pytest"]},


### PR DESCRIPTION
## Description

This PR fixes the deprecation of `pkg_resources` by moving to `importlib.resources` (or on Python < 3.9, the backport `importlib_resources` for the "files" API). The removal happened in `setuptools@82`,
https://setuptools.pypa.io/en/latest/history.html#v82-0-0

This fixes an issue in `hls-vi-historical` where we had erroneously pinned `setuptools` to ensure recent versions 😭,
https://github.com/NASA-IMPACT/hls-vi-historical/blob/v0.5/pyproject.toml#L26-L28